### PR TITLE
Fix broken link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 #maitira.com
 
 ## What is it?
-It's the website for [maitria.com](maitria.com). It started just HTML & CSS. Duplication meant it was time to pull in SASS, and now here comes Clojure. It's definitely a place for learning.
+It's the website for [maitria.com](http://maitria.com/). It started just HTML & CSS. Duplication meant it was time to pull in SASS, and now here comes Clojure. It's definitely a place for learning.
 
 ## Why is our website open source? 
 - to add to beginner-friendly open source possibilities


### PR DESCRIPTION
The link to http://maitria.com/ contained no http-prefix so it pointed to https://github.com/maitria/maitria.com/blob/master/maitria.com .

If this was left in to give a beginner an easy first achievement on his/her way into Open Source, you can deny this request. I'm already hooked to FOSS. ;)
